### PR TITLE
Ulrike s91 remove referenceDataset/Project

### DIFF
--- a/v1.0/brainAtlas.schema.tpl.json
+++ b/v1.0/brainAtlas.schema.tpl.json
@@ -25,12 +25,6 @@
       "minItems": 1,
       "uniqueItems": true
     },
-    "referenceProject": {
-      "_instruction": "Add the reference project for this brain atlas.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/Project"
-      ]
-    },
     "shortName": {
       "type": "string",
       "_instruction": "Enter a descriptive short name for this brain atlas."

--- a/v1.0/brainAtlasVersion.schema.tpl.json
+++ b/v1.0/brainAtlasVersion.schema.tpl.json
@@ -46,12 +46,6 @@
         "https://openminds.ebrains.eu/sands/BrainAtlasVersion"
       ]
     },
-    "referenceDataset": {
-      "_instruction": "Add the reference dataset for this brain atlas version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/DatasetVersion"
-      ]
-    },
     "relatedOntology": {
       "type": "string",
       "_instruction": "Enter the identifier (IRI) of the related ontological term matching this brain atlas version.",


### PR DESCRIPTION
Based on comments in PR #94 and additional discussion with @lzehl, we decided to remove `referenceDataset` and `referenceProject` from `brainAtlas(Version)`, because we have more direct references/links via `fileInstances`.

If a need for these fields becomes more clear later, they can be added again. 